### PR TITLE
feat: Support layout directory

### DIFF
--- a/generator/template/src/router.js
+++ b/generator/template/src/router.js
@@ -6,7 +6,7 @@ import { createRouterLayout } from 'vue-router-layout'
 Vue.use(Router)
 
 const RouterLayout = createRouterLayout(layout => {
-  return import('@/layouts/' + layout + '.vue')
+  return import(`@/layouts/${layout}`)
 })
 
 export default new Router({


### PR DESCRIPTION
Before modification, `src/layouts` directory only support defined single `.vue` file , example:
```text
├── layouts
│   └── default.vue
│   └── user.vue
```
After modification,`src/layouts` directory can support directory resolve `index` file under the directory, and single `.vue` file

```text
├── layouts
│   ├── auth.vue
│   ├── default
│   │   ├── Footer.vue
│   │   ├── Header.vue
│   │   ├── Main.vue
│   │   ├── Navigation.vue
│   │   └── index.vue
│   └── user
│       ├── Footer.vue
│       ├── Header.vue
│       ├── Main.vue
│       ├── Navigation.vue
│       └── index.vue
``` 