### PR TITLE
feat: added custom output file option (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ After adding the plugin, the file structure will be the below.
 src/
 ├── pages/
 ├── layouts/
-└── router.js
+└── router/
 ```
 
 ### Pages
@@ -181,7 +181,9 @@ You can see the available options list [here](https://github.com/ktsn/vue-route-
 module.exports = {
   pluginOptions: {
     autoRouting: {
-      // Specify vue-auto-routing options here
+      // Optionally specify a custom output file, relative to the project root
+      outFile: "src/router/routes.js",
+      // Specify other vue-auto-routing options here
       nested: false
     }
   }

--- a/generator/template/src/router/index.js
+++ b/generator/template/src/router/index.js
@@ -10,6 +10,8 @@ const RouterLayout = createRouterLayout(layout => {
 })
 
 export default new Router({
+  mode: "history",
+  base: process.env.BASE_URL,
   routes: [
     {
       path: '/',

--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ const defaultOptions = {
 }
 
 module.exports = (api, options) => {
+  const opts = options.pluginOptions && options.pluginOptions.autoRouting
   const pluginOptions = {
     ...defaultOptions,
-    ...(options.pluginOptions && options.pluginOptions.autoRouting),
+    ...opts,
+    outFile: (opts && opts.outFile && api.resolve(opts.outFile)) || undefined,
   }
 
   api.chainWebpack((webpackConfig) => {


### PR DESCRIPTION
Fixes #46 

This solution allows for an option named `outFile` to be specified, relative to the project root. The provided path gets resolved through the plugin API before passed to `vue-auto-routing`.

Also edited the template to reflect the new functionality.

**Note:** Two new defaults has been added to the router instance options (`mode` must be specified, `base` for convenience).
```
mode: "history",
base: process.env.BASE_URL,
```